### PR TITLE
Fix imports for Render deployment

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -3,7 +3,8 @@
 from fastapi import FastAPI
 import random
 
-from routes.random_routes import router as random_router
+# Required for deployment on Render: use full import path from /src root
+from src.routes.random_routes import router as random_router
 
 app = FastAPI()
 app.include_router(random_router)

--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from fastapi import APIRouter
 
-from utils.random_picker import load_items_from_file, pick_random_item
+# Required for deployment on Render: use full import path from /src root
+from src.utils.random_picker import load_items_from_file, pick_random_item
 
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- import `random_routes` using full package path
- fix utils import for Render deployment

## Testing
- `python -m py_compile dune-backend/src/dice.py`

------
https://chatgpt.com/codex/tasks/task_e_685ea6d342108329a188cd1d2853fe9b