### PR TITLE
Fix Render imports

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -3,8 +3,9 @@
 from fastapi import FastAPI
 import random
 
-# Required for deployment on Render: use full import path from /src root
-from src.routes.random_routes import router as random_router
+# Required for deployment on Render: the app is executed from within ``src``
+# so we import routes as local packages instead of using the ``src`` prefix.
+from routes.random_routes import router as random_router
 
 app = FastAPI()
 app.include_router(random_router)

--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from fastapi import APIRouter
 
-# Required for deployment on Render: use full import path from /src root
-from src.utils.random_picker import load_items_from_file, pick_random_item
+# Required for deployment on Render: import from local ``utils`` package
+from utils.random_picker import pick_random_item, load_items_from_file
 
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- adjust imports so Render can run the FastAPI app from within `dune-backend/src`

## Testing
- `python -m py_compile dune-backend/src/dice.py`

------
https://chatgpt.com/codex/tasks/task_e_685ea96a43848329b04d80281461d1d3