### PR TITLE
Fix FastAPI import paths

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -5,7 +5,7 @@ import random
 
 # Required for deployment on Render: the app is executed from within ``src``
 # so we import routes as local packages instead of using the ``src`` prefix.
-from routes.random_routes import router as random_router
+from src.routes.random_routes import router as random_router
 
 app = FastAPI()
 app.include_router(random_router)

--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from fastapi import APIRouter
 
 # Required for deployment on Render: import from local ``utils`` package
-from utils.random_picker import pick_random_item, load_items_from_file
+from src.utils.random_picker import pick_random_item, load_items_from_file
 
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- fix package imports so `uvicorn src.dice:app` loads correctly
- add missing `__init__.py` under `src`

## Testing
- `python -m py_compile dune-backend/src/dice.py`
- `uvicorn src.dice:app --host 0.0.0.0 --port 10000` *(from `dune-backend` directory)*

------
https://chatgpt.com/codex/tasks/task_e_685f1cc2812c8329b71d54dedb51d2fc