### PR TITLE
Add expanded random scenario generation

### DIFF
--- a/dune-backend/data/allies.txt
+++ b/dune-backend/data/allies.txt
@@ -1,0 +1,3 @@
+A mysterious mentat
+A band of smugglers
+A Fremen guide

--- a/dune-backend/data/antagonists.txt
+++ b/dune-backend/data/antagonists.txt
@@ -1,0 +1,3 @@
+A scheming rival house
+A corrupt spice smuggler
+A renegade Bene Gesserit

--- a/dune-backend/data/artifacts.txt
+++ b/dune-backend/data/artifacts.txt
@@ -1,0 +1,3 @@
+Ancient crysknife
+Forbidden spice stash
+Holographic map

--- a/dune-backend/data/consequences.txt
+++ b/dune-backend/data/consequences.txt
@@ -1,0 +1,3 @@
+Gain favor with the Emperor
+House falls into disgrace
+Unexpected alliance forms

--- a/dune-backend/data/environment.txt
+++ b/dune-backend/data/environment.txt
@@ -1,0 +1,3 @@
+Raging sandstorm
+Deep desert at night
+Political intrigue on Kaitain

--- a/dune-backend/data/mysticism.txt
+++ b/dune-backend/data/mysticism.txt
@@ -1,0 +1,3 @@
+Visions from the spice
+A prophetic dream
+A mysterious Bene Gesserit ritual

--- a/dune-backend/data/objectives.txt
+++ b/dune-backend/data/objectives.txt
@@ -1,0 +1,3 @@
+Retrieve a stolen artifact
+Assassinate a rival noble
+Forge an alliance with Fremen

--- a/dune-backend/data/twists.txt
+++ b/dune-backend/data/twists.txt
@@ -1,0 +1,3 @@
+The ally is secretly an enemy
+The objective is a trap
+A sandstorm disrupts everything

--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from fastapi import APIRouter
 
 # Required for deployment on Render: import from local ``utils`` package
-from src.utils.random_picker import pick_random_item, load_items_from_file
+from src.utils.random_picker import pick_random_item_from_file
 
 
 router = APIRouter()
@@ -10,13 +10,28 @@ router = APIRouter()
 DATA_DIR = Path(__file__).resolve().parents[2] / "data"
 HOUSES_FILE = DATA_DIR / "houses.txt"
 SETTINGS_FILE = DATA_DIR / "settings.txt"
+OBJECTIVES_FILE = DATA_DIR / "objectives.txt"
+ANTAGONISTS_FILE = DATA_DIR / "antagonists.txt"
+TWISTS_FILE = DATA_DIR / "twists.txt"
+ALLIES_FILE = DATA_DIR / "allies.txt"
+ENVIRONMENT_FILE = DATA_DIR / "environment.txt"
+ARTIFACTS_FILE = DATA_DIR / "artifacts.txt"
+MYSTICISM_FILE = DATA_DIR / "mysticism.txt"
+CONSEQUENCES_FILE = DATA_DIR / "consequences.txt"
 
 
 @router.get("/random_scenario")
 def get_random_scenario() -> dict:
-    """Return a random house paired with a random setting."""
-    houses = load_items_from_file(HOUSES_FILE)
-    settings = load_items_from_file(SETTINGS_FILE)
-    house = pick_random_item(houses)
-    setting = pick_random_item(settings)
-    return {"house": house, "setting": setting}
+    """Return a randomly generated scenario pulling one item from each data file."""
+    return {
+        "house": pick_random_item_from_file(HOUSES_FILE),
+        "setting": pick_random_item_from_file(SETTINGS_FILE),
+        "objective": pick_random_item_from_file(OBJECTIVES_FILE),
+        "antagonist": pick_random_item_from_file(ANTAGONISTS_FILE),
+        "twist": pick_random_item_from_file(TWISTS_FILE),
+        "ally": pick_random_item_from_file(ALLIES_FILE),
+        "environment": pick_random_item_from_file(ENVIRONMENT_FILE),
+        "artifact": pick_random_item_from_file(ARTIFACTS_FILE),
+        "mystical": pick_random_item_from_file(MYSTICISM_FILE),
+        "consequence": pick_random_item_from_file(CONSEQUENCES_FILE),
+    }

--- a/dune-backend/src/utils/random_picker.py
+++ b/dune-backend/src/utils/random_picker.py
@@ -16,3 +16,9 @@ def pick_random_item(items: Sequence[str]) -> str:
     if not items:
         raise ValueError("No items to choose from")
     return random.choice(list(items))
+
+
+def pick_random_item_from_file(path: Path) -> str:
+    """Return a random non-blank line from ``path``."""
+    items = load_items_from_file(path)
+    return pick_random_item(items)


### PR DESCRIPTION
## Summary
- add more data files to build a full scenario
- extend random_routes `/random_scenario` endpoint
- update random_picker with helper to load from file

## Testing
- `python -m py_compile dune-backend/src/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685f278f15348329b375e5d2f5b8f12c