### PR TITLE
Add GPT-Based Adventure Generator Endpoint

### DIFF
--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 
 # Required for deployment on Render: import from local ``utils`` package
 from src.utils.random_picker import pick_random_item_from_file
+from src.utils.scenario_utils import generate_adventure_text
 
 
 router = APIRouter()
@@ -35,3 +36,10 @@ def get_random_scenario() -> dict:
         "mystical": pick_random_item_from_file(MYSTICISM_FILE),
         "consequence": pick_random_item_from_file(CONSEQUENCES_FILE),
     }
+
+
+@router.post("/generate_adventure")
+def generate_adventure(scenario: dict) -> dict:
+    """Return GPT-generated adventure text for the given scenario."""
+    adventure_text = generate_adventure_text(scenario)
+    return {"adventure_text": adventure_text}

--- a/dune-backend/src/utils/scenario_utils.py
+++ b/dune-backend/src/utils/scenario_utils.py
@@ -1,0 +1,30 @@
+import openai
+
+
+def generate_adventure_text(scenario: dict) -> str:
+    """Generate an adventure summary using GPT-4 based on the provided scenario."""
+    scenario_text = "\n".join(f"- {k.capitalize()}: {v}" for k, v in scenario.items())
+
+    prompt = f"""
+You are a Dune storyteller tasked with creating a rich, immersive adventure summary.
+
+Using the elements below, write a 1–2 paragraph narrative hook that could open a TTRPG session or campaign. The tone should be consistent with the lore of the Dune universe — mysterious, political, philosophical, and dangerous.
+
+Resolve any contradictory elements creatively rather than removing them. Use Dune terminology and imagery. Avoid second-person voice.
+
+Scenario Elements:
+{scenario_text}
+
+Begin your summary:
+"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": "You are a Dune campaign narrator."},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.75,
+    )
+
+    return response["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- implement `generate_adventure_text` in new `scenario_utils.py` using GPT-4
- create a new `/generate_adventure` route returning GPT narrative text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f329e6e608329b179b73f3c4fd2cd