### PR TITLE
Add CORS middleware to FastAPI

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -1,6 +1,7 @@
 """Minimal FastAPI app providing simple D20 dice rolls."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 import random
 
 # Required for deployment on Render: the app is executed from within ``src``
@@ -8,6 +9,14 @@ import random
 from src.routes.random_routes import router as random_router
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(random_router)
 
 


### PR DESCRIPTION
## Summary
- enable CORS in the backend FastAPI app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4400a2d483298daee6035a227571