### PR TITLE
Add quick scenario endpoint

### DIFF
--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from fastapi import APIRouter, Body
 
 # Required for deployment on Render: import from local ``utils`` package
-from src.utils.random_picker import pick_random_item_from_file
+from src.utils.random_picker import pick_random_item_from_file, get_random_scenario
 from src.utils.scenario_utils import generate_adventure_text
 
 
@@ -22,19 +22,20 @@ CONSEQUENCES_FILE = DATA_DIR / "consequences.txt"
 
 
 @router.get("/random_scenario")
-def get_random_scenario() -> dict:
+def random_scenario() -> dict:
     """Return a randomly generated scenario pulling one item from each data file."""
+    return get_random_scenario()
+
+
+@router.get("/scenario_elements")
+def quick_scenario() -> dict:
+    """Return random scenario elements instantly plus a follow-up prompt."""
+    scenario = get_random_scenario()
     return {
-        "house": pick_random_item_from_file(HOUSES_FILE),
-        "setting": pick_random_item_from_file(SETTINGS_FILE),
-        "objective": pick_random_item_from_file(OBJECTIVES_FILE),
-        "antagonist": pick_random_item_from_file(ANTAGONISTS_FILE),
-        "twist": pick_random_item_from_file(TWISTS_FILE),
-        "ally": pick_random_item_from_file(ALLIES_FILE),
-        "environment": pick_random_item_from_file(ENVIRONMENT_FILE),
-        "artifact": pick_random_item_from_file(ARTIFACTS_FILE),
-        "mystical": pick_random_item_from_file(MYSTICISM_FILE),
-        "consequence": pick_random_item_from_file(CONSEQUENCES_FILE),
+        "scenario": scenario,
+        "prompt": (
+            "Would you like me to craft these elements into a powerful scenario?"
+        ),
     }
 
 

--- a/dune-backend/src/utils/random_picker.py
+++ b/dune-backend/src/utils/random_picker.py
@@ -22,3 +22,32 @@ def pick_random_item_from_file(path: Path) -> str:
     """Return a random non-blank line from ``path``."""
     items = load_items_from_file(path)
     return pick_random_item(items)
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+HOUSES_FILE = DATA_DIR / "houses.txt"
+SETTINGS_FILE = DATA_DIR / "settings.txt"
+OBJECTIVES_FILE = DATA_DIR / "objectives.txt"
+ANTAGONISTS_FILE = DATA_DIR / "antagonists.txt"
+TWISTS_FILE = DATA_DIR / "twists.txt"
+ALLIES_FILE = DATA_DIR / "allies.txt"
+ENVIRONMENT_FILE = DATA_DIR / "environment.txt"
+ARTIFACTS_FILE = DATA_DIR / "artifacts.txt"
+MYSTICISM_FILE = DATA_DIR / "mysticism.txt"
+CONSEQUENCES_FILE = DATA_DIR / "consequences.txt"
+
+
+def get_random_scenario() -> dict[str, str]:
+    """Return a randomly generated scenario pulling one item from each data file."""
+    return {
+        "house": pick_random_item_from_file(HOUSES_FILE),
+        "setting": pick_random_item_from_file(SETTINGS_FILE),
+        "objective": pick_random_item_from_file(OBJECTIVES_FILE),
+        "antagonist": pick_random_item_from_file(ANTAGONISTS_FILE),
+        "twist": pick_random_item_from_file(TWISTS_FILE),
+        "ally": pick_random_item_from_file(ALLIES_FILE),
+        "environment": pick_random_item_from_file(ENVIRONMENT_FILE),
+        "artifact": pick_random_item_from_file(ARTIFACTS_FILE),
+        "mystical": pick_random_item_from_file(MYSTICISM_FILE),
+        "consequence": pick_random_item_from_file(CONSEQUENCES_FILE),
+    }


### PR DESCRIPTION
## Summary
- import `get_random_scenario` helper
- expose helper via `/random_scenario`
- add new GET `/scenario_elements` endpoint for instant scenario
- centralize helper in `random_picker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6fe1d5188329a3e6d970beace740