### PR TITLE
Add simple command router to chat backend

### DIFF
--- a/dune-backend/src/dice.py
+++ b/dune-backend/src/dice.py
@@ -7,6 +7,7 @@ import random
 # Required for deployment on Render: the app is executed from within ``src``
 # so we import routes as local packages instead of using the ``src`` prefix.
 from src.routes.random_routes import router as random_router
+from routes.chat_routes import router as chat_router
 
 app = FastAPI()
 
@@ -18,6 +19,7 @@ app.add_middleware(
 )
 
 app.include_router(random_router)
+app.include_router(chat_router)
 
 
 @app.get("/")

--- a/dune-backend/src/routes/chat_routes.py
+++ b/dune-backend/src/routes/chat_routes.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Body
+from utils.command_router import handle_command
+
+router = APIRouter()
+
+
+@router.post("/chat")
+def chat_endpoint(message: str = Body(..., embed=True)) -> dict:
+    """
+    Lightweight chat endpoint.
+    If message starts with '| ' we run the command router.
+    Otherwise we just echo (you can later wire this into OpenAI chat).
+    """
+    cmd_response = handle_command(message)
+    if cmd_response is not None:
+        return {"response": cmd_response}
+
+    # Default fallback — for now just echo. Swap with GPT later.
+    return {"response": f"You said: {message}"}
+

--- a/dune-backend/src/utils/command_router.py
+++ b/dune-backend/src/utils/command_router.py
@@ -1,0 +1,43 @@
+"""Utility functions to parse and execute in-chat commands that start with '| '."""
+
+from utils.random_picker import get_random_scenario
+
+
+def cmd_create_scenario() -> str:
+    """Generate random scenario elements and return a nicely formatted string."""
+    s = get_random_scenario()
+    lines = [
+        "**Random Dune Scenario Elements**",
+        f"- **House:** {s['house']}",
+        f"- **Setting:** {s['setting']}",
+        f"- **Objective:** {s['objective']}",
+        f"- **Antagonist:** {s['antagonist']}",
+        f"- **Twist:** {s['twist']}",
+        f"- **Ally:** {s['ally']}",
+        f"- **Environment:** {s['environment']}",
+        f"- **Artifact:** {s['artifact']}",
+        f"- **Mystical:** {s['mystical']}",
+        f"- **Consequence:** {s['consequence']}",
+        "",
+        "*Would you like me to craft these elements into a powerful scenario?*"
+    ]
+    return "\n".join(lines)
+
+
+COMMAND_MAP = {
+    "create scenario": cmd_create_scenario
+}
+
+
+def handle_command(raw: str) -> str | None:
+    """If *raw* begins with '| ', parse the command and execute.
+    Otherwise return None."""
+    if not raw.lstrip().startswith("|"):
+        return None
+
+    cmd = raw.lstrip()[1:].strip().lower()          # drop leading '|'
+    fn = COMMAND_MAP.get(cmd)
+    if fn:
+        return fn()
+    return f"Unrecognized command: `{cmd}`"
+


### PR DESCRIPTION
## Summary
- implement a command router capable of parsing pipe-prefixed commands
- add a chat endpoint that can execute in-chat commands
- register the new chat router with the FastAPI app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f76e79a3483299ba82983f9afaa3e