### PR TITLE
Move chat_routes into routes package

### DIFF
--- a/dune-backend/src/routes/chat_routes.py
+++ b/dune-backend/src/routes/chat_routes.py
@@ -3,18 +3,15 @@ from utils.command_router import handle_command
 
 router = APIRouter()
 
-
 @router.post("/chat")
 def chat_endpoint(message: str = Body(..., embed=True)) -> dict:
     """
-    Lightweight chat endpoint.
-    If message starts with '| ' we run the command router.
-    Otherwise we just echo (you can later wire this into OpenAI chat).
+    Chat entrypoint. If the message begins with '| ', execute a backend command;
+    otherwise, just echo (placeholder for future GPT chat).
     """
     cmd_response = handle_command(message)
     if cmd_response is not None:
         return {"response": cmd_response}
 
-    # Default fallback — for now just echo. Swap with GPT later.
     return {"response": f"You said: {message}"}
 


### PR DESCRIPTION
## Summary
- move chat routes into `routes` package and update content
- ensure `dice.py` still imports the router
- keep empty `__init__.py` in the routes package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f79a06bfc83298e7d0c52ce42f666