### PR TITLE
Improve command parsing

### DIFF
--- a/dune-backend/src/utils/command_router.py
+++ b/dune-backend/src/utils/command_router.py
@@ -36,7 +36,9 @@ def handle_command(raw: str) -> str | None:
         return None
 
     cmd = raw.lstrip()[1:].strip().lower()          # drop leading '|'
-    fn = COMMAND_MAP.get(cmd)
+    cmd = cmd.rstrip('!?.,')                        # drop trailing punctuation
+    cmd_key = " ".join(cmd.split()[:2])            # first two words for synonyms
+    fn = COMMAND_MAP.get(cmd) or COMMAND_MAP.get(cmd_key)
     if fn:
         return fn()
     return f"Unrecognized command: `{cmd}`"

--- a/dune-backend/tests/test_command_router.py
+++ b/dune-backend/tests/test_command_router.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+# Allow imports from dune-backend/src
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.utils.command_router import handle_command
+
+HEADER = "**Random Dune Scenario Elements**"
+
+def test_non_command_returns_none():
+    assert handle_command("hello") is None
+
+def test_create_scenario_synonym_parses():
+    result = handle_command("| create scenario please!")
+    assert result.startswith(HEADER)
+
+def test_punctuation_stripped():
+    result = handle_command("| create scenario?!")
+    assert result.startswith(HEADER)


### PR DESCRIPTION
## Summary
- support synonyms and trailing punctuation in `handle_command`
- test additional parsing cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fbaa6c84c83298c6f6c1e86da4fff