### PR TITLE
Add command input and backend messaging

### DIFF
--- a/chatbot-ui/src/App.js
+++ b/chatbot-ui/src/App.js
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import "./App.css";
-import { fetchD20, fetch2D20 } from "./api";
+import { fetchD20, fetch2D20, sendMessage } from "./api";
 
 function App() {
   const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState("");
 
   const rollD20 = async () => {
     try {
@@ -24,6 +25,27 @@ function App() {
     } catch (err) {
       setMessages((msgs) => [...msgs, `\u274c Roll failed: ${err.message}`]);
     }
+  };
+
+  const sendChat = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    try {
+      const data = await sendMessage(input);
+      if (data.response) {
+        setMessages((msgs) => [...msgs, data.response]);
+      } else if (data.scenario) {
+        const lines = Object.entries(data.scenario)
+          .map(([k, v]) => `- ${k}: ${v}`)
+          .join("\n");
+        setMessages((msgs) => [...msgs, `${lines}\n${data.prompt}`]);
+      } else {
+        setMessages((msgs) => [...msgs, JSON.stringify(data)]);
+      }
+    } catch (err) {
+      setMessages((msgs) => [...msgs, `\u274c Command failed: ${err.message}`]);
+    }
+    setInput("");
   };
 
   return (
@@ -48,6 +70,20 @@ function App() {
           </div>
         ))}
       </div>
+      <form onSubmit={sendChat} data-testid="command-form" className="mt-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Enter command"
+          className="border p-2 rounded w-64"
+        />
+        <button
+          type="submit"
+          className="ml-2 px-4 py-2 rounded shadow hover:bg-gray-200"
+        >
+          Send
+        </button>
+      </form>
     </div>
   );
 }

--- a/chatbot-ui/src/App.test.js
+++ b/chatbot-ui/src/App.test.js
@@ -21,3 +21,13 @@ test('roll 2d20 button fetches dice array', async () => {
   fireEvent.click(screen.getByText(/Roll 2d20/i));
   await waitFor(() => screen.getByText(/You rolled 3 and 17/i));
 });
+
+test('sending command posts to backend', async () => {
+  jest.spyOn(api, 'sendMessage').mockResolvedValue({ response: 'ok' });
+  render(<App />);
+  fireEvent.change(screen.getByPlaceholderText(/Enter command/i), {
+    target: { value: '|test' },
+  });
+  fireEvent.submit(screen.getByTestId('command-form'));
+  await waitFor(() => screen.getByText(/ok/i));
+});

--- a/chatbot-ui/src/api.js
+++ b/chatbot-ui/src/api.js
@@ -15,3 +15,28 @@ export async function fetch2D20() {
   const data = await res.json();
   return data.results;
 }
+
+export async function sendMessage(message) {
+  const trimmed = message.trim();
+  let url = 'http://localhost:8000/chat';
+  let body = { message };
+
+  if (
+    trimmed.startsWith('|') &&
+    trimmed.slice(1).trim().toLowerCase() === 'create scenario'
+  ) {
+    url = 'http://localhost:8000/generate_scenario';
+    body = {};
+  }
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`API error: ${res.status}`);
+  }
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- extend api with `sendMessage` for chat and scenario generation
- allow App to send text commands and show results
- test sending commands from the UI

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685fbabc99ec8329a985132cad1419ba