### PR TITLE
Add GET endpoint for create scenario

### DIFF
--- a/chatbot-ui/src/api.js
+++ b/chatbot-ui/src/api.js
@@ -20,21 +20,22 @@ export async function fetch2D20() {
 
 export async function sendMessage(message) {
   const trimmed = message.trim();
-  let url = `${API_BASE}/chat`;
-  let body = { message };
 
   if (
     trimmed.startsWith('|') &&
     trimmed.slice(1).trim().toLowerCase() === 'create scenario'
   ) {
-    url = `${API_BASE}/generate_scenario`;
-    body = {};
+    const res = await fetch(`${API_BASE}/generate_scenario`);
+    if (!res.ok) {
+      throw new Error(`API error: ${res.status}`);
+    }
+    return await res.json();
   }
 
-  const res = await fetch(url, {
+  const res = await fetch(`${API_BASE}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ message }),
   });
 
   if (!res.ok) {

--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -52,6 +52,16 @@ def generate_scenario(scenario: dict | None = None) -> dict:
     }
 
 
+@router.get("/generate_scenario")
+def generate_scenario_get() -> dict:
+    """GET variant of :func:`generate_scenario` returning random elements."""
+    scenario = get_random_scenario()
+    return {
+        "scenario": scenario,
+        "prompt": "Would you like me to craft these elements into a powerful scenario?",
+    }
+
+
 @router.post("/generate_adventure")
 def generate_adventure(scenario: dict) -> dict:
     """Return GPT-generated adventure text for the given scenario."""


### PR DESCRIPTION
## Summary
- add GET `/generate_scenario` API route that mirrors the POST version
- adjust frontend `sendMessage` to use GET for `| create scenario`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffa191f2883299cb97c5197b5f1fa