### PR TITLE
Add GET endpoint for test command

### DIFF
--- a/chatbot-ui/src/api.js
+++ b/chatbot-ui/src/api.js
@@ -20,21 +20,30 @@ export async function fetch2D20() {
 
 export async function sendMessage(message) {
   const trimmed = message.trim();
-  let url = `${API_BASE}/chat`;
-  let body = { message };
 
   if (
     trimmed.startsWith('|') &&
     trimmed.slice(1).trim().toLowerCase() === 'create scenario'
   ) {
-    url = `${API_BASE}/generate_scenario`;
-    body = {};
+    const res = await fetch(`${API_BASE}/generate_scenario`);
+    if (!res.ok) {
+      throw new Error(`API error: ${res.status}`);
+    }
+    return await res.json();
   }
 
-  const res = await fetch(url, {
+  if (trimmed.startsWith('|') && trimmed.slice(1).trim().toLowerCase() === 'test') {
+    const res = await fetch(`${API_BASE}/test`);
+    if (!res.ok) {
+      throw new Error(`API error: ${res.status}`);
+    }
+    return await res.json();
+  }
+
+  const res = await fetch(`${API_BASE}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ message }),
   });
 
   if (!res.ok) {

--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -2,8 +2,12 @@ from pathlib import Path
 from fastapi import APIRouter, Body
 
 # Required for deployment on Render: import from local ``utils`` package
-from src.utils.random_picker import pick_random_item_from_file, get_random_scenario
+from src.utils.random_picker import (
+    pick_random_item_from_file,
+    get_random_scenario,
+)
 from src.utils.scenario_utils import generate_adventure_text
+from src.utils.command_router import cmd_test
 
 
 router = APIRouter()
@@ -50,6 +54,22 @@ def generate_scenario(scenario: dict | None = None) -> dict:
         "scenario": scenario,
         "prompt": "Would you like me to craft these elements into a powerful scenario?",
     }
+
+
+@router.get("/generate_scenario")
+def generate_scenario_get() -> dict:
+    """GET variant of :func:`generate_scenario` returning random elements."""
+    scenario = get_random_scenario()
+    return {
+        "scenario": scenario,
+        "prompt": "Would you like me to craft these elements into a powerful scenario?",
+    }
+
+
+@router.get("/test")
+def test_get() -> dict:
+    """GET variant for the ``| test`` command."""
+    return {"response": cmd_test()}
 
 
 @router.post("/generate_adventure")


### PR DESCRIPTION
## Summary
- add GET `/test` API route mirroring the `| test` command
- update frontend to call `/test` when `| test` is sent
- keep existing `| create scenario` handling via GET

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ffa191f2883299cb97c5197b5f1fa