### PR TITLE
Add /scenario_story route and command

### DIFF
--- a/dune-backend/src/routes/random_routes.py
+++ b/dune-backend/src/routes/random_routes.py
@@ -74,3 +74,11 @@ def generate_adventure(scenario: dict) -> dict:
     """Return GPT-generated adventure text for the given scenario."""
     adventure_text = generate_adventure_text(scenario)
     return {"adventure_text": adventure_text}
+
+
+@router.get("/scenario_story")
+def scenario_story() -> dict:
+    """Return a complete narrative in one call."""
+    scenario = get_random_scenario()
+    story = generate_adventure_text(scenario, max_tokens=800)
+    return {"response": story}

--- a/dune-backend/src/utils/command_router.py
+++ b/dune-backend/src/utils/command_router.py
@@ -1,5 +1,7 @@
 """Utility functions to parse and execute in-chat commands that start with '| '."""
 
+import os
+import requests
 from src.utils.random_picker import get_random_scenario
 
 
@@ -24,6 +26,14 @@ def cmd_create_scenario() -> str:
     return "\n".join(lines)
 
 
+def cmd_scenario_story() -> str:
+    """Call the backend /scenario_story endpoint and return its text."""
+    base = os.getenv("BACKEND_URL", "http://localhost:8000")
+    r = requests.get(f"{base}/scenario_story", timeout=30)
+    r.raise_for_status()
+    return r.json()["response"]
+
+
 def cmd_test() -> str:
     """Return a confirmation that the command system works."""
     return "Test Satisfactory"
@@ -31,6 +41,7 @@ def cmd_test() -> str:
 
 COMMAND_MAP = {
     "create scenario": cmd_create_scenario,
+    "scenario story":  cmd_scenario_story,
     "test": cmd_test,
 }
 

--- a/dune-backend/src/utils/scenario_utils.py
+++ b/dune-backend/src/utils/scenario_utils.py
@@ -5,8 +5,9 @@ from fastapi import HTTPException
 client = OpenAI()  # Uses OPENAI_API_KEY from env
 
 
-def generate_adventure_text(scenario: dict) -> str:
-    """Generate an adventure summary using GPT-4 based on the provided scenario."""
+def generate_adventure_text(scenario: dict, max_tokens: int | None = None) -> str:
+    """Generate an adventure summary using GPT-4 based on the provided scenario.
+    Optionally set ``max_tokens`` for the response."""
     scenario_text = "\n".join(f"- {k.capitalize()}: {v}" for k, v in scenario.items())
 
     prompt = f"""
@@ -30,6 +31,7 @@ Begin your summary:
                 {"role": "user", "content": prompt},
             ],
             temperature=0.75,
+            max_tokens=max_tokens,
         )
     except openai.OpenAIError as exc:
         # When the request fails (e.g., missing API key or network issue),

--- a/dune-backend/tests/test_command_router.py
+++ b/dune-backend/tests/test_command_router.py
@@ -4,6 +4,7 @@ import sys
 # Allow imports from dune-backend/src
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from src.utils import command_router
 from src.utils.command_router import handle_command
 
 HEADER = "**Random Dune Scenario Elements**"
@@ -22,3 +23,23 @@ def test_punctuation_stripped():
 
 def test_test_command():
     assert handle_command("| test") == "Test Satisfactory"
+
+
+def test_scenario_story_command(monkeypatch):
+    """Ensure the scenario story command calls the backend and returns text."""
+
+    class DummyResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"response": "dummy story"}
+
+    def fake_get(url, timeout=30):
+        assert url.endswith("/scenario_story")
+        return DummyResponse()
+
+    monkeypatch.setattr(command_router.requests, "get", fake_get)
+
+    result = handle_command("| scenario story")
+    assert result == "dummy story"


### PR DESCRIPTION
## Summary
- implement new `/scenario_story` GET endpoint in random_routes
- support `max_tokens` in `generate_adventure_text`
- add command router client for `/scenario_story`
- update command mapping and add tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686087130d3c832993826450d3b3ae86